### PR TITLE
Chore: Add missing modal.js

### DIFF
--- a/layouts/_default/snap-packages.html
+++ b/layouts/_default/snap-packages.html
@@ -81,6 +81,7 @@
 {{ end }}
 {{ define "scripts" }}
     (() => {
+        {{- partial "js/modal.js" . | safeJS -}}
         {{- partial "js/sortable.js" . | safeJS -}}
         {{- partial "js/expand.js" . | safeJS -}}
         {{- partial "js/accordion.js" . | safeJS -}}


### PR DESCRIPTION
The modal dialogs when you click the eye icon by a commit or version number in the dashboard do not work. Fix that by making sure the dashboard loads modal.js