### PR TITLE
fix: only create one nav row to align nav items better

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -13,8 +13,6 @@
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
       <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
-  </div>
-  <div class="p-navigation__row">
     {{ partial "menu.html" (dict "menuID" "main" "page" .) }}
   </div>
 </header>


### PR DESCRIPTION
The "Dashboard" item was placed oddly in the middle of the nav bar, and it's because there were two navigation rows.

This places the "Dashboard" link next to the snapcrafters logo - another option would be to pull it to the right hand edge of the nav bar.

![image](https://github.com/snapcrafters/snapcrafters.org/assets/668505/01816d79-b90d-4da4-a6c7-19e12c8156ab)
