### PR TITLE
feat: enable display of tags as well as releases and commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Rebuild the site
         env:
           RELEASEGEN_TOKEN: ${{ secrets.SNAPCRAFTERS_BOT_READ }}
-          RELEASEGEN_VERSION: "0.4.3"
+          RELEASEGEN_VERSION: "0.5.0"
         run: |
           wget -qO releasegen.tar.gz "https://github.com/jnsgruk/releasegen/releases/download/v${RELEASEGEN_VERSION}/releasegen_${RELEASEGEN_VERSION}_linux_x86_64.tar.gz"
           tar xvzf releasegen.tar.gz

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -95,12 +95,11 @@
     }
 
     .repo-icon-gh {
-      background-image: linear-gradient(to right, rgba(255, 255, 255, 0.3) 0 100%), url({{ absURL "github.svg" }});
+      background-image: linear-gradient(to right, rgba(255, 255, 255, 0.3) 0 100%), url({{absURL "github.svg"}});
     }
 
     .repo-icon-lp {
-      background-image: linear-gradient(to right, rgba(255, 255, 255, 0.3) 0 100%),
-        url({{ absURL "launchpad.svg" }});
+      background-image: linear-gradient(to right, rgba(255, 255, 255, 0.3) 0 100%), url({{absURL "launchpad.svg"}});
     }
   </style>
 </head>

--- a/layouts/partials/repo.html
+++ b/layouts/partials/repo.html
@@ -20,14 +20,20 @@
         <small>
           <a class="p-icon--show" aria-controls="{{ $modal_id }}" role="modal-open"></a>
           <a target="_blank" href="{{ $release.url }}">{{ $release.version }}</a>
-          <time datetime="{{- int $release.timestamp }}">
-            <span class="u-hide--small">
-              on {{ (time (int $release.timestamp)).Format "Jan 2, 2006" }}
-            </span>
-          </time>
         </small>
         </p>
         {{- partial "modal" (dict "title" $release.title "url" $release.url "body" $release.body "timestamp" $release.timestamp "repo" $.repo "team" $.team "id" $modal_id) -}}
+      {{- end -}}
+    {{- else if not (not .repo.tags) -}}
+      {{- range $tag := .repo.tags -}}
+        {{- $modal_id := printf "%s-%s" $.team.team $tag.sha -}}
+        <p class="u-no-margin--bottom" aria-release-date="{{ $tag.timestamp }}">
+        <small>
+          <a class="p-icon--show" aria-controls="{{ $modal_id }}" role="modal-open"></a>
+          <a target="_blank" href="{{ $tag.url }}">{{ $tag.name }}</a>
+        </small>
+        </p>
+        {{- partial "modal" (dict "title" $tag.name "url" $tag.url "body" $tag.body "timestamp" $tag.timestamp "repo" $.repo "team" $.team "id" $modal_id) -}} 
       {{- end -}}
     {{- else if not (not .repo.commits) -}}
       {{- range $commit := .repo.commits -}}
@@ -36,11 +42,6 @@
         <small>
           <a class="p-icon--show" aria-controls="{{ $modal_id }}" role="modal-open"></a>
           <a target="_blank" href="{{ $commit.url }}">{{ substr $commit.sha 0 7 }}</a>
-          <time datetime="{{- int $commit.timestamp }}">
-            <span class="u-hide--small">
-              on {{ (time (int $commit.timestamp)).Format "Jan 2, 2006" }}
-            </span>
-          </time>
         </small>
         </p>
         {{- partial "modal" (dict "title" (substr $commit.sha 0 7) "url" $commit.url "body" $commit.message "timestamp" $commit.timestamp "repo" $.repo "team" $.team "id" $modal_id) -}} 


### PR DESCRIPTION
This uses a new release of `releasegen`. Previously `releasegen` only parsed Github Releases and commits. With our new auto-tagging system I thought it might be useful to display those tags (because they also illuminate snap versions).

See below for an example of what this will look like:

![image](https://github.com/snapcrafters/snapcrafters.org/assets/668505/7c043a6d-9d06-44e7-b983-bafb923124a1)
